### PR TITLE
Fallback description language

### DIFF
--- a/abaplint.json
+++ b/abaplint.json
@@ -132,7 +132,7 @@
     "parser_error": true,
     "preferred_compare_operator": true,
     "release_idoc": true,
-    "remove_descriptions": true,
+    "remove_descriptions": false,
     "rfc_error_handling": true,
     "sequential_blank": true,
     "short_case": true,

--- a/src/zcl_abapgit_tran_to_bran.clas.abap
+++ b/src/zcl_abapgit_tran_to_bran.clas.abap
@@ -279,7 +279,6 @@ CLASS zcl_abapgit_tran_to_bran IMPLEMENTATION.
     mo_repo = io_repo.
 
     LOOP AT zcl_bg_factory=>get_transports( )->list_open( ) INTO DATA(lv_trkorr).
-
       DATA(lt_objects) = zcl_bg_factory=>get_objects( )->to_r3tr(
         zcl_bg_factory=>get_transports( )->list_contents( lv_trkorr ) ).
 

--- a/src/zcl_bg_transports.clas.abap
+++ b/src/zcl_bg_transports.clas.abap
@@ -11,7 +11,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_BG_TRANSPORTS IMPLEMENTATION.
+CLASS zcl_bg_transports IMPLEMENTATION.
 
 
   METHOD zif_bg_transports~list_contents.
@@ -60,8 +60,14 @@ CLASS ZCL_BG_TRANSPORTS IMPLEMENTATION.
     SELECT SINGLE as4text FROM e07t
       INTO rv_description
       WHERE trkorr = iv_trkorr AND langu = sy-langu.
-    IF sy-subrc <> 0.
-      RAISE EXCEPTION TYPE zcx_abapgit_exception.
+    IF sy-subrc <> 0. " If language does not exist try to find another description.
+      SELECT SINGLE as4text FROM e07t
+           INTO rv_description
+           WHERE trkorr = iv_trkorr.
+      IF sy-subrc <> 0.
+        RAISE EXCEPTION TYPE zcx_abapgit_desc_exception.
+      ENDIF.
+
     ENDIF.
 
   ENDMETHOD.
@@ -72,7 +78,7 @@ CLASS ZCL_BG_TRANSPORTS IMPLEMENTATION.
       FROM e070
       WHERE trkorr = @iv_trkorr.
     IF sy-subrc <> 0.
-      RAISE EXCEPTION TYPE zcx_abapgit_exception.
+      RAISE EXCEPTION TYPE zcx_abapgit_user_exception.
     ENDIF.
   ENDMETHOD.
 ENDCLASS.

--- a/src/zcx_abapgit_desc_exception.clas.abap
+++ b/src/zcx_abapgit_desc_exception.clas.abap
@@ -25,7 +25,7 @@ ENDCLASS.
 CLASS zcx_abapgit_desc_exception IMPLEMENTATION.
 
 
-  METHOD constructor.
+  METHOD constructor ##ADT_SUPPRESS_GENERATION.
     CALL METHOD super->constructor
       EXPORTING
         previous = previous

--- a/src/zcx_abapgit_desc_exception.clas.abap
+++ b/src/zcx_abapgit_desc_exception.clas.abap
@@ -25,7 +25,7 @@ ENDCLASS.
 CLASS zcx_abapgit_desc_exception IMPLEMENTATION.
 
 
-  METHOD constructor ##ADT_SUPPRESS_GENERATION.
+  METHOD constructor.
     CALL METHOD super->constructor
       EXPORTING
         previous = previous

--- a/src/zcx_abapgit_desc_exception.clas.abap
+++ b/src/zcx_abapgit_desc_exception.clas.abap
@@ -1,0 +1,45 @@
+CLASS zcx_abapgit_desc_exception DEFINITION
+  PUBLIC
+  INHERITING FROM zcx_abapgit_exception
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+
+    METHODS constructor
+      IMPORTING
+        !textid   LIKE if_t100_message=>t100key OPTIONAL
+        !previous LIKE previous OPTIONAL
+        !log      TYPE REF TO zif_abapgit_log OPTIONAL
+        !msgv1    TYPE symsgv OPTIONAL
+        !msgv2    TYPE symsgv OPTIONAL
+        !msgv3    TYPE symsgv OPTIONAL
+        !msgv4    TYPE symsgv OPTIONAL
+        !longtext TYPE csequence OPTIONAL .
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+
+CLASS zcx_abapgit_desc_exception IMPLEMENTATION.
+
+
+  METHOD constructor ##ADT_SUPPRESS_GENERATION.
+    CALL METHOD super->constructor
+      EXPORTING
+        previous = previous
+        log      = log
+        msgv1    = msgv1
+        msgv2    = msgv2
+        msgv3    = msgv3
+        msgv4    = msgv4
+        longtext = longtext.
+    CLEAR me->textid.
+    IF textid IS INITIAL.
+      if_t100_message~t100key = if_t100_message=>default_textid.
+    ELSE.
+      if_t100_message~t100key = textid.
+    ENDIF.
+  ENDMETHOD.
+ENDCLASS.

--- a/src/zcx_abapgit_desc_exception.clas.xml
+++ b/src/zcx_abapgit_desc_exception.clas.xml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCX_ABAPGIT_DESC_EXCEPTION</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Description not found</DESCRIPT>
+    <CATEGORY>40</CATEGORY>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+   <DESCRIPTIONS>
+    <SEOCOMPOTX>
+     <CMPNAME>CONSTRUCTOR</CMPNAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>CONSTRUCTOR</DESCRIPT>
+    </SEOCOMPOTX>
+   </DESCRIPTIONS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zcx_abapgit_user_exception.clas.abap
+++ b/src/zcx_abapgit_user_exception.clas.abap
@@ -1,0 +1,45 @@
+CLASS zcx_abapgit_user_exception DEFINITION
+  PUBLIC
+  INHERITING FROM zcx_abapgit_exception
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+
+    METHODS constructor
+      IMPORTING
+        !textid   LIKE if_t100_message=>t100key OPTIONAL
+        !previous LIKE previous OPTIONAL
+        !log      TYPE REF TO zif_abapgit_log OPTIONAL
+        !msgv1    TYPE symsgv OPTIONAL
+        !msgv2    TYPE symsgv OPTIONAL
+        !msgv3    TYPE symsgv OPTIONAL
+        !msgv4    TYPE symsgv OPTIONAL
+        !longtext TYPE csequence OPTIONAL .
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+
+CLASS zcx_abapgit_user_exception IMPLEMENTATION.
+
+
+  METHOD constructor ##ADT_SUPPRESS_GENERATION.
+    CALL METHOD super->constructor
+      EXPORTING
+        previous = previous
+        log      = log
+        msgv1    = msgv1
+        msgv2    = msgv2
+        msgv3    = msgv3
+        msgv4    = msgv4
+        longtext = longtext.
+    CLEAR me->textid.
+    IF textid IS INITIAL.
+      if_t100_message~t100key = if_t100_message=>default_textid.
+    ELSE.
+      if_t100_message~t100key = textid.
+    ENDIF.
+  ENDMETHOD.
+ENDCLASS.

--- a/src/zcx_abapgit_user_exception.clas.abap
+++ b/src/zcx_abapgit_user_exception.clas.abap
@@ -25,7 +25,7 @@ ENDCLASS.
 CLASS zcx_abapgit_user_exception IMPLEMENTATION.
 
 
-  METHOD constructor.
+  METHOD constructor ##ADT_SUPPRESS_GENERATION.
     CALL METHOD super->constructor
       EXPORTING
         previous = previous

--- a/src/zcx_abapgit_user_exception.clas.abap
+++ b/src/zcx_abapgit_user_exception.clas.abap
@@ -25,7 +25,7 @@ ENDCLASS.
 CLASS zcx_abapgit_user_exception IMPLEMENTATION.
 
 
-  METHOD constructor ##ADT_SUPPRESS_GENERATION.
+  METHOD constructor.
     CALL METHOD super->constructor
       EXPORTING
         previous = previous

--- a/src/zcx_abapgit_user_exception.clas.xml
+++ b/src/zcx_abapgit_user_exception.clas.xml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCX_ABAPGIT_USER_EXCEPTION</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>User not found exception</DESCRIPT>
+    <CATEGORY>40</CATEGORY>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+   <DESCRIPTIONS>
+    <SEOCOMPOTX>
+     <CMPNAME>CONSTRUCTOR</CMPNAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>CONSTRUCTOR</DESCRIPT>
+    </SEOCOMPOTX>
+   </DESCRIPTIONS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
If no description exists for sy-langu this PR will fallback to any other description existing for the current transport. Also I've added this sub-exceptions to distinguis between user-does-not-exist and description-does-not-exist.

See issue [11](https://github.com/abapGit/background_modes/issues/11)